### PR TITLE
Added an UnmanagedEventReceiver and a EventReceivers list-helper.

### DIFF
--- a/lifecycle/src/main/java/com/talk4date/android/lifecycle/EventReceiver.java
+++ b/lifecycle/src/main/java/com/talk4date/android/lifecycle/EventReceiver.java
@@ -23,18 +23,19 @@ public interface EventReceiver<T> {
 	 * Adds a listener that is notified when the event receiver is destroyed.
 	 * @see #isDestroyed()
 	 */
-	void addOnDestroyListener(OnDestroyListener listener);
+	void addOnDestroyListener(OnDestroyListener<T> listener);
 
 	/**
 	 * Removes a previously added destroy listener.
 	 */
-	void removeOnDestroyListener(OnDestroyListener listener);
+	void removeOnDestroyListener(OnDestroyListener<T> listener);
 
-	public static interface OnDestroyListener {
+	public static interface OnDestroyListener<T> {
 
 		/**
 		 * Called when the event receiver is destroyed.
+		 * @param eventReceiver the event receiver which was destroyed.
 		 */
-		void onDestroy();
+		void onDestroy(EventReceiver<T> eventReceiver);
 	}
 }

--- a/lifecycle/src/main/java/com/talk4date/android/lifecycle/EventReceivers.java
+++ b/lifecycle/src/main/java/com/talk4date/android/lifecycle/EventReceivers.java
@@ -1,0 +1,33 @@
+package com.talk4date.android.lifecycle;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * List of event receivers which makes sure destroyed event receivers are removed from the list,
+ * and also allows simply posting of events to all contained eventreceivers.
+ */
+public class EventReceivers<T> implements EventReceiver.OnDestroyListener<T> {
+	private List<EventReceiver<T>> eventReceivers = new ArrayList<>();
+
+	public void registerEventReceiver(EventReceiver<T> eventReceiver) {
+		eventReceivers.add(eventReceiver);
+		eventReceiver.addOnDestroyListener(this);
+	}
+
+	public void unregisterEventReceiver(EventReceiver<T> eventReceiver) {
+		eventReceiver.removeOnDestroyListener(this);
+		eventReceivers.remove(eventReceiver);
+	}
+
+	@Override
+	public void onDestroy(EventReceiver<T> eventReceiver) {
+		unregisterEventReceiver(eventReceiver);
+	}
+
+	public void postEvent(T event) {
+		for (EventReceiver<T> receiver : eventReceivers) {
+			receiver.postEvent(event);
+		}
+	}
+}

--- a/lifecycle/src/main/java/com/talk4date/android/lifecycle/LifecycleEventDispatcher.java
+++ b/lifecycle/src/main/java/com/talk4date/android/lifecycle/LifecycleEventDispatcher.java
@@ -50,7 +50,7 @@ public class LifecycleEventDispatcher<T> implements EventReceiver<T>, Lifecycle.
 	/**
 	 * List of all on destroy listeners.
 	 */
-	private List<OnDestroyListener> onDestroyListeners = new LinkedList<>();
+	private List<OnDestroyListener<T>> onDestroyListeners = new LinkedList<>();
 
 	/**
 	 * If the lifecycle has been destroyed.
@@ -87,8 +87,8 @@ public class LifecycleEventDispatcher<T> implements EventReceiver<T>, Lifecycle.
 	public void onDestroy() {
 		this.destroyed = true;
 
-		for (OnDestroyListener listener : onDestroyListeners) {
-			listener.onDestroy();
+		for (OnDestroyListener<T> listener : onDestroyListeners) {
+			listener.onDestroy(this);
 		}
 
 		// Long running processes might still have references to us and keep us and alive.
@@ -188,12 +188,12 @@ public class LifecycleEventDispatcher<T> implements EventReceiver<T>, Lifecycle.
 	}
 
 	@Override
-	public void addOnDestroyListener(OnDestroyListener listener) {
+	public void addOnDestroyListener(OnDestroyListener<T> listener) {
 		this.onDestroyListeners.add(listener);
 	}
 
 	@Override
-	public void removeOnDestroyListener(OnDestroyListener listener) {
+	public void removeOnDestroyListener(OnDestroyListener<T> listener) {
 		this.onDestroyListeners.remove(listener);
 	}
 }

--- a/lifecycle/src/main/java/com/talk4date/android/lifecycle/UnmanagedEventReceiver.java
+++ b/lifecycle/src/main/java/com/talk4date/android/lifecycle/UnmanagedEventReceiver.java
@@ -1,0 +1,64 @@
+package com.talk4date.android.lifecycle;
+
+import android.os.Handler;
+import android.os.Looper;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * An event receiver which is not managed by a lifecycle, can be used if a event receiver is required
+ * but no lifecycle is required.
+ */
+public abstract class UnmanagedEventReceiver<T> implements EventReceiver<T>, EventListener<T> {
+
+	private Handler mainHandler = new Handler(Looper.getMainLooper());
+
+	private boolean destroyed = false;
+
+	List<OnDestroyListener<T>> listeners = new ArrayList<>();
+
+	@Override
+	public void postEvent(final T event) {
+		if (isDestroyed()) {
+			return;
+		}
+
+		if (Looper.myLooper() == Looper.getMainLooper()) {
+			onEvent(event);
+		} else {
+			mainHandler.post(new Runnable() {
+				@Override
+				public void run() {
+					onEvent(event);
+				}
+			});
+		}
+	}
+
+	@Override
+	public boolean isDestroyed() {
+		return destroyed;
+	}
+
+	public void destroy() {
+		this.destroyed = true;
+		notifyOnDestroyListeners();
+	}
+
+	private void notifyOnDestroyListeners() {
+		for (OnDestroyListener listener : listeners) {
+			listener.onDestroy(this);
+		}
+	}
+
+	@Override
+	public void addOnDestroyListener(OnDestroyListener<T> listener) {
+		listeners.add(listener);
+	}
+
+	@Override
+	public void removeOnDestroyListener(OnDestroyListener<T> listener) {
+		listeners.remove(listener);
+	}
+}


### PR DESCRIPTION
- `UnmanagedEventReceiver`: Useful if callers need an EventReceiver
  without an lifecycle (e.g. for singletons which live for the
  duration of an app)
- `EventReceivers`: A utility class which allows simple managing of a
  list of EventReceiver. It will keep track of when event receivers are
  destroyed and remove them from the list. It also provides one
  postEvent method will which distribute it to all `EventReceiver`s.
